### PR TITLE
Support newer Pyramid versions and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=pyramid13
   - TOX_ENV=pyramid14
+  - TOX_ENV=pyramid15
+  - TOX_ENV=pyramid16
+  - TOX_ENV=pyramid17
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,23 @@ language: python
 python: 2.7
 env:
   - TOX_ENV=py27
-  - TOX_ENV=pyramid13
-  - TOX_ENV=pyramid14
-  - TOX_ENV=pyramid15
-  - TOX_ENV=pyramid16
-  - TOX_ENV=pyramid17
+  - TOX_ENV=py27-pyramid13
+  - TOX_ENV=py27-pyramid14
+  - TOX_ENV=py27-pyramid15
+  - TOX_ENV=py27-pyramid16
+  - TOX_ENV=py27-pyramid17
+  - TOX_ENV=py34
+  - TOX_ENV=py34-pyramid15
+  - TOX_ENV=py34-pyramid16
+  - TOX_ENV=py34-pyramid17
+  - TOX_ENV=py35
+  - TOX_ENV=py35-pyramid15
+  - TOX_ENV=py35-pyramid16
+  - TOX_ENV=py35-pyramid17
+  - TOX_ENV=py36
+  - TOX_ENV=py36-pyramid15
+  - TOX_ENV=py36-pyramid16
+  - TOX_ENV=py36-pyramid17
 install:
   - pip install tox
 script:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.0 (Unreleased)
+----------------
+
+- Fix compatibility with Pyramid 1.6 and newer. If you relied on using the
+  descriptor feature of SkinObject, you now have to use BindableSkinObject
+  instead.
+  [fschulze]
+
+
 1.2 (2014-09-23)
 ----------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Changelog
   instead.
   [fschulze]
 
+- Support Python 3.
+  [fschulze]
+
 
 1.2 (2014-09-23)
 ----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,9 @@ cover-erase=1
 
 [upload_sphinx]
 upload-dir = _build/html
+
+[bdist_wheel]
+universal = 1
+
+[devpi:upload]
+formats = sdist.tgz,bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if sys.platform.startswith("linux"):
     testing_extras.append("pyinotify")
 
 setup(name='pyramid_skins',
-      version = '1.2',
+      version = '2.0',
       description='Templating framework for Pyramid.',
       long_description=long_description,
       keywords = "pyramid templates",

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.txt')).read()
-CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
+README = open(os.path.join(here, 'README.txt'), 'rb').read()
+CHANGES = open(os.path.join(here, 'CHANGES.txt'), 'rb').read()
 
-long_description = "\n\n".join((README, CHANGES))
+long_description = b"\n\n".join((README, CHANGES))
 long_description = long_description.decode('utf-8')
 
 requires = [

--- a/src/pyramid_skins/__init__.py
+++ b/src/pyramid_skins/__init__.py
@@ -1,4 +1,4 @@
-from pyramid_skins.models import SkinObject
+from pyramid_skins.models import BindableSkinObject, SkinObject  # noqa
 from pyramid_skins.routes import RoutesTraverserFactory
 from configuration import register_path
 

--- a/src/pyramid_skins/__init__.py
+++ b/src/pyramid_skins/__init__.py
@@ -1,6 +1,6 @@
 from pyramid_skins.models import BindableSkinObject, SkinObject  # noqa
 from pyramid_skins.routes import RoutesTraverserFactory
-from configuration import register_path
+from pyramid_skins.configuration import register_path
 
 
 def includeme(config):

--- a/src/pyramid_skins/configuration.py
+++ b/src/pyramid_skins/configuration.py
@@ -3,6 +3,7 @@ import pkg_resources
 import weakref
 
 from pyramid.asset import resolve_asset_spec
+from pyramid.compat import bytes_, text_
 from pyramid.path import caller_path
 from pyramid_skins.interfaces import ISkinObject
 from pyramid_skins.interfaces import ISkinObjectFactory
@@ -15,7 +16,7 @@ def walk(path):
         for filename in filenames:
             full_path = os.path.join(dir_path, filename)
             rel_path = full_path[len(path) + 1:]
-            yield rel_path.replace(os.path.sep, '/'), str(full_path)
+            yield rel_path.replace(os.path.sep, '/'), full_path
 
 
 def dirs(path):
@@ -78,7 +79,7 @@ class Skins(object):
     def __init__(self, config, path=None, discovery=False, request_type=None):
         self.config = config
         self.registry = config.registry
-        self.path = os.path.realpath(path).encode('utf-8')
+        self.path = os.path.realpath(text_(path))
         self.views = []
         self.request_type = config.maybe_dotted(request_type)
 

--- a/src/pyramid_skins/discovery.py
+++ b/src/pyramid_skins/discovery.py
@@ -1,8 +1,19 @@
 import logging
+import sys
 import threading
 
 
 logger = logging.getLogger("pyramid_skins")
+
+PY2 = sys.version_info[0] == 2
+
+
+def string(s):
+    if isinstance(s, str):
+        return s
+    if PY2:
+        return s.encode('utf-8')
+    return s.decode('utf-8')
 
 
 class Discoverer(threading.Thread):
@@ -35,11 +46,12 @@ class Discoverer(threading.Thread):
 
             def callback(subpath, subdir):
                 for path, handler in self.paths.items():
+                    path = string(path)
                     if subpath.startswith(path):
                         config = handler.configure()
                         config.commit()
 
-            stream = self.fsevents.Stream(callback, *self.paths)
+            stream = self.fsevents.Stream(callback, *(string(x) for x in self.paths))
             observer = self.fsevents.Observer()
             observer.schedule(stream)
             observer.run()

--- a/src/pyramid_skins/docs/registration.rst
+++ b/src/pyramid_skins/docs/registration.rst
@@ -65,6 +65,7 @@ At this point the skin objects are available as utility
 components. This is the low-level interface::
 
   from zope.component import getUtility
+  from pyramid.compat import text_
   from pyramid_skins.interfaces import ISkinObject
   index = getUtility(ISkinObject, name="index")
 
@@ -79,8 +80,8 @@ The component name is available in the ``name`` attribute::
 
 .. -> expr
 
-  >>> eval(expr)
-  'index'
+  >>> print(text_(eval(expr)))
+  index
 
 We now move up one layer and consider the skin components as objects.
 
@@ -120,7 +121,7 @@ tag of the HTML document::
 .. -> output
 
   >>> exec(code)
-  >>> response.body.replace('\n\n', '\n') == output
+  >>> response.body.replace(b'\n\n', b'\n') == output.encode('utf-8')
   True
   >>> response.content_type == 'text/html'
   True
@@ -267,7 +268,7 @@ passed ``'Hello world!'`` as the view context::
   >>> from pyramid.testing import DummyRequest
   >>> frontpage1 = render_view('Hello world!', DummyRequest(), name="frontpage1")
   >>> frontpage2 = render_view('Hello world!', DummyRequest(), name="frontpage2")
-  >>> frontpage1.replace('\n\n', '\n') == frontpage2.replace('\n\n', '\n') == output
+  >>> frontpage1.replace(b'\n\n', b'\n') == frontpage2.replace(b'\n\n', b'\n') == output.encode('utf-8')
   True
 
 Renderer
@@ -358,7 +359,7 @@ Let's add a new skin template with the source:
       # add new file for discovery
       g = tempfile.NamedTemporaryFile(dir=dir, suffix=".pt")
       try:
-          g.write(source)
+          g.write(source.encode('utf-8'))
           g.flush()
 
           name = os.path.splitext(os.path.basename(g.name))[0]
@@ -382,7 +383,7 @@ Let's add a new skin template with the source:
   finally:
       shutil.rmtree(tmppath)
 
-  >>> print output
+  >>> print(output)
   200 OK
   Content-Length: 24
   Content-Type: text/html; charset=UTF-8

--- a/src/pyramid_skins/docs/registration.rst
+++ b/src/pyramid_skins/docs/registration.rst
@@ -95,8 +95,6 @@ The ``SkinObject`` class itself wraps the low-level utility lookup::
 .. -> code
 
   >>> exec(code)
-  >>> FrontPage.__get__() is not None
-  True
 
 This object is a callable which will render the template to a response
 (it could be an image, stylesheet or some other resource type). In the
@@ -208,8 +206,10 @@ In Pyramid we can also define a view using a class which provides
 ``__init__`` and ``__call__``. The call method must return a
 response. With skin objects, we can express it this way::
 
+  from pyramid_skins import BindableSkinObject
+
   class FrontPageView(object):
-      __call__ = SkinObject("index")
+      __call__ = BindableSkinObject("index")
 
       def __init__(self, context, request):
           self.context = context

--- a/src/pyramid_skins/docs/routing.rst
+++ b/src/pyramid_skins/docs/routing.rst
@@ -35,7 +35,7 @@ To expose the contents of a skin directory as *views*, we can insert a
   >>> from pyramid.testing import DummyRequest
   >>> render_view('Hello world!', DummyRequest(), name="") is None
   True
-  >>> print render_view('Hello world!', DummyRequest(), name="index")
+  >>> print(render_view('Hello world!', DummyRequest(), name="index").decode('utf-8'))
   <html>
     <body>
       Hello world!
@@ -66,7 +66,7 @@ allow registering default index views (e.g. ``index.pt``):
   ...   <include package="pyramid_skins" />
   ...   %(configuration)s
   ... </configure>""".strip() % locals())
-  >>> print render_view('Hello world!', DummyRequest(), name="")
+  >>> print(render_view('Hello world!', DummyRequest(), name="").decode('utf-8'))
   <html>
     <body>
       Hello world!
@@ -110,7 +110,7 @@ factory:
   ...     'REQUEST_METHOD':'GET',
   ...     'PATH_INFO':'/static/images/logo.png',
   ...     }
-  >>> def start_response(*args): print args
+  >>> def start_response(*args): print(args)
   >>> from pyramid.interfaces import IRoutesMapper
   >>> from zope.component import getUtility
   >>> router.root_factory = getUtility(IRoutesMapper)

--- a/src/pyramid_skins/docs/templates.rst
+++ b/src/pyramid_skins/docs/templates.rst
@@ -51,8 +51,8 @@ The pipe operator lets us provide one or more fallback options::
   ...     f.flush()
   ...     from pyramid_skins.zcml import register_skin_object
   ...     register_skin_object(registry, string, f.name, None)
-  ...     from pyramid_skins import SkinObject
-  ...     inst = SkinObject(string)
+  ...     from pyramid_skins import BindableSkinObject
+  ...     inst = BindableSkinObject(string)
   ...     try:
   ...         return inst(**context).body
   ...     finally:
@@ -123,8 +123,8 @@ the skins path registered for the ``IRequest`` layer
 
 This applies also to the ``SkinObject`` constructor:
 
-  >>> from pyramid_skins import SkinObject
-  >>> bound = SkinObject("main_template").__get__()
+  >>> from pyramid_skins import BindableSkinObject
+  >>> bound = BindableSkinObject("main_template")
   >>> response = bound()
   >>> print response.body
   <html>

--- a/src/pyramid_skins/docs/templates.rst
+++ b/src/pyramid_skins/docs/templates.rst
@@ -47,22 +47,22 @@ The pipe operator lets us provide one or more fallback options::
   >>> def render_template(string, **context):
   ...     from tempfile import NamedTemporaryFile
   ...     f = NamedTemporaryFile(suffix=".pt")
-  ...     f.write(string)
+  ...     f.write(string.encode('utf-8'))
   ...     f.flush()
   ...     from pyramid_skins.zcml import register_skin_object
   ...     register_skin_object(registry, string, f.name, None)
   ...     from pyramid_skins import BindableSkinObject
   ...     inst = BindableSkinObject(string)
   ...     try:
-  ...         return inst(**context).body
+  ...         return inst(**context).body.decode('utf-8')
   ...     finally:
   ...         f.close()
 
   >>> template = "<div %s tal:replace='inst.path' />"
 
-  >>> print render_template(template % define_main_template)
+  >>> print(render_template(template % define_main_template))
   /.../skins/main_template.pt
-  >>> print render_template(template % define_logo)
+  >>> print(render_template(template % define_logo))
   /.../skins/images/logo.png
 
 Whitespace is ignored in any case. Skin lookups are either absolute or
@@ -100,7 +100,7 @@ relative.
   >>> from zope.component import getUtility
   >>> from pyramid_skins.interfaces import ISkinObject
   >>> about = getUtility(ISkinObject, name="about/index")
-  >>> print about(context=u"Hello world!").body
+  >>> print(about(context=u"Hello world!").body.decode('utf-8'))
   <html>
    ... <img src="/about/images/logo.png" /> ...
   </html>
@@ -118,7 +118,7 @@ We can now see that the 'main_template' skin object is resolved from
 the skins path registered for the ``IRequest`` layer
 (``"alt_skins"``):
 
-  >>> print render_template(template % define_main_template)
+  >>> print(render_template(template % define_main_template))
   /.../alt_skins/main_template.pt
 
 This applies also to the ``SkinObject`` constructor:
@@ -126,7 +126,7 @@ This applies also to the ``SkinObject`` constructor:
   >>> from pyramid_skins import BindableSkinObject
   >>> bound = BindableSkinObject("main_template")
   >>> response = bound()
-  >>> print response.body
+  >>> print(response.body.decode('utf-8'))
   <html>
     <title>Alternative</title>
     <body>
@@ -154,7 +154,7 @@ learn how you can set up a route to serve up skin objects as static
 resources or even views.
 
   >>> route = add_route("/static", "static")
-  >>> print render_template(source)
+  >>> print(render_template(source))
   <img src="http://example.com/static/images/logo.png" />
 
 This is a convenient way to compute the URL for static resources. See
@@ -177,7 +177,7 @@ attribute to reach them::
 
 .. -> source
 
-  >>> print render_template(source)
+  >>> print(render_template(source))
   <body>
     Inserted.
   </body>
@@ -193,7 +193,7 @@ the entire template is rendered::
 
 .. -> source
 
-  >>> print render_template(source)
+  >>> print(render_template(source))
   <html>
     <body>
       Inserted.

--- a/src/pyramid_skins/models.py
+++ b/src/pyramid_skins/models.py
@@ -2,8 +2,7 @@ import os
 import mimetypes
 import functools
 
-from zope.interface import implements
-from zope.interface import classProvides
+from zope.interface import implementer, provider
 try:
     from zope.interface.interfaces import ComponentLookupError
 except ImportError:
@@ -13,6 +12,7 @@ from chameleon.zpt.template import PageTemplateFile
 from chameleon.tales import ProxyExpr
 from chameleon.tales import TalesExpr
 
+from pyramid.compat import string_types
 from pyramid.response import Response
 from pyramid.threadlocal import get_current_request
 from pyramid.threadlocal import get_current_registry
@@ -71,9 +71,9 @@ if TalesExpr not in ProxyExpr.__bases__:
             return compiler(target, None)
 
 
+@implementer(ISkinObject)
+@provider(ISkinObjectFactory)
 class SkinObject(object):
-    implements(ISkinObject)
-    classProvides(ISkinObjectFactory)
 
     _bound_kwargs = {}
     content_type = 'application/octet-stream'
@@ -101,7 +101,7 @@ class SkinObject(object):
             return inst(context=context, request=request, **kw)
 
         result = self.render(context=context, request=request, **kw)
-        if isinstance(result, basestring):
+        if isinstance(result, string_types):
             response = Response(body=result)
         else:
             response = Response(app_iter=result)
@@ -127,7 +127,7 @@ class SkinObject(object):
         pass
 
     def render(self, **kw):
-        return file(self.path)
+        return open(self.path, 'rb')
 
 
 class BindableSkinObject(SkinObject):

--- a/src/pyramid_skins/tests/test_renderer.py
+++ b/src/pyramid_skins/tests/test_renderer.py
@@ -41,12 +41,12 @@ class RendererTest(unittest.TestCase):
     def register_skins(self, paths):
         from pyramid.interfaces import IRequest
         from pyramid_skins.configuration import register_path
-        import new
+        from types import ClassType
 
         skins = {}
         for path in paths:
             name = os.path.basename(path)
-            interface = new.classobj(
+            interface = ClassType(
                 'IThemeRequest-%s' % name,
                 (IRequest, ),
                 dict(__doc__=""" marker interface for custom theme """))

--- a/src/pyramid_skins/tests/test_renderer.py
+++ b/src/pyramid_skins/tests/test_renderer.py
@@ -36,20 +36,18 @@ class RendererTest(unittest.TestCase):
         from pyramid.view import render_view
         from pyramid.threadlocal import get_current_request
         result = render_view('Hello world!', get_current_request(), 'index')
-        self.assertTrue('Hello world' in result)
+        self.assertTrue(b'Hello world' in result)
 
     def register_skins(self, paths):
         from pyramid.interfaces import IRequest
         from pyramid_skins.configuration import register_path
-        from types import ClassType
 
         skins = {}
         for path in paths:
             name = os.path.basename(path)
-            interface = ClassType(
-                'IThemeRequest-%s' % name,
-                (IRequest, ),
-                dict(__doc__=""" marker interface for custom theme """))
+            class interface(IRequest):
+                __doc__ = """ marker interface for custom theme """
+            interface.__name__ = 'IThemeRequest-%s' % name
             skin = register_path(self.config, path, request_type=interface)
             skins[name] = dict(
                 skin=skin,
@@ -75,7 +73,7 @@ class RendererTest(unittest.TestCase):
 
         alsoProvides(get_current_request(), skins['alt_skins']['interface'])
         result = render_view('Hello world!', get_current_request(), 'index')
-        self.assertTrue('Alternative' in result)
+        self.assertTrue(b'Alternative' in result)
 
     def test_multiple_skins_other(self):
         from pyramid.threadlocal import get_current_request
@@ -96,7 +94,7 @@ class RendererTest(unittest.TestCase):
 
         alsoProvides(get_current_request(), skins['other_skins']['interface'])
         result = render_view('Hello world!', get_current_request(), 'index')
-        self.assertTrue('Other' in result)
+        self.assertTrue(b'Other' in result)
 
     def test_skin_reload(self):
         from pyramid_skins.configuration import register_path
@@ -110,7 +108,7 @@ class RendererTest(unittest.TestCase):
             skins_dir = os.path.join(tmp, 'skins')
             os.mkdir(skins_dir)
             with open(os.path.join(skins_dir, 'index.pt'), 'wb') as f:
-                f.write('<html><title>Alternative</title></html>')
+                f.write(b'<html><title>Alternative</title></html>')
 
             skins = self.register_skins([skins_dir])
 
@@ -126,11 +124,11 @@ class RendererTest(unittest.TestCase):
             from pyramid.threadlocal import get_current_request
             alsoProvides(get_current_request(), skins['skins']['interface'])
             result = render_view('Hello world!', get_current_request(), 'index')
-            self.assertTrue('Alternative' in result)
+            self.assertTrue(b'Alternative' in result)
             with open(os.path.join(skins_dir, 'index.pt'), 'wb') as f:
-                f.write('<html><title>Other</title></html>')
+                f.write(b'<html><title>Other</title></html>')
             skins['skins']['skin'].configure()
             result = render_view('Hello world!', get_current_request(), 'index')
-            self.assertTrue('Other' in result)
+            self.assertTrue(b'Other' in result)
         finally:
             shutil.rmtree(tmp)

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,15 @@
 [tox]
 envlist =
-    py27,pyramid13,pyramid14
+    py27{,-pyramid13,-pyramid14,-pyramid15,-pyramid16,-pyramid17}
 
 [testenv]
 commands =
     pip install pyramid_skins[testing]
     nosetests
-
-[testenv:pyramid13]
-basepython = python2.7
 deps =
-    pyramid-zcml==0.9.2
-    pyramid>=1.3,<1.4dev
-
-[testenv:pyramid14]
-basepython = python2.7
-deps =
-    pyramid>=1.4,<1.5dev
+    pyramid13: pyramid-zcml==0.9.2
+    pyramid13: pyramid>=1.3,<1.4dev
+    pyramid14: pyramid>=1.4,<1.5dev
+    pyramid15: pyramid>=1.5,<1.6dev
+    pyramid16: pyramid>=1.6,<1.7dev
+    pyramid17: pyramid>=1.7,<1.8dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27{,-pyramid13,-pyramid14,-pyramid15,-pyramid16,-pyramid17}
+    py27{,-pyramid13,-pyramid14,-pyramid15,-pyramid16,-pyramid17},py{34,35,36}{,-pyramid15,-pyramid16,-pyramid17}
 
 [testenv]
 commands =


### PR DESCRIPTION
Pyramid 1.3 - 1.7 are directly supported and the tests run. Pyramid 1.8 currently fails because of pyramid_zcml, once that is fixed the tests work as well.
Added support for Python 3.4-3.6.